### PR TITLE
Add `TIDEWAYS_SOURCE` to identify as official docker image

### DIFF
--- a/daemon/docker-entrypoint.sh
+++ b/daemon/docker-entrypoint.sh
@@ -11,7 +11,8 @@ fi
 if [ "$1" = "tideways-daemon" ]; then
 	shift # "tideways-daemon"
 
-	TIDEWAYS_SOURCE=official-image
+	export TIDEWAYS_SOURCE=official-image
+
 	TIDEWAYS_DAEMON_EXTRA=
 	if [ -f /etc/default/tideways-daemon ]; then
 		source /etc/default/tideways-daemon

--- a/daemon/docker-entrypoint.sh
+++ b/daemon/docker-entrypoint.sh
@@ -11,6 +11,7 @@ fi
 if [ "$1" = "tideways-daemon" ]; then
 	shift # "tideways-daemon"
 
+	TIDEWAYS_SOURCE=official-image
 	TIDEWAYS_DAEMON_EXTRA=
 	if [ -f /etc/default/tideways-daemon ]; then
 		source /etc/default/tideways-daemon


### PR DESCRIPTION
The next daemon can provide metadata to the backend in which way it was installed. This helps with better customer support responses.