### PR TITLE
php: Simplify the end-user installation with a helper script

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -2,23 +2,35 @@ FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.source="https://github.com/tideways/container-images"
 
-RUN set -eux; \
-	export DEBIAN_FRONTEND="noninteractive"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-	; \
-	rm -rf /var/lib/apt/lists/*
-
-COPY tideways.asc /usr/share/keyrings/tideways.asc
+COPY --chmod=0755 get-ext-path.php /tideways/
 
 ENV TIDEWAYS_PHP_VERSION 5.9.0
+ENV TIDEWAYS_PHP_SHA256_X64 cbadbc49558ece142ec431b3c1291c5374e081c25345877f31aedcb9ee2e78f6
+ENV TIDEWAYS_PHP_SHA256_ARM64 42f76a2ecb2f9f545570e81c8623d0cf2e72e78a6b0b90a434cbeaba6c9a5227
 
 RUN set -eux; \
 	export DEBIAN_FRONTEND="noninteractive"; \
-	echo 'deb [signed-by=/usr/share/keyrings/tideways.asc] https://packages.tideways.com/apt-packages-main any-version main' |tee /etc/apt/sources.list.d/tideways.list; \
+	buildDeps='curl ca-certificates'; \
 	apt-get update; \
-	apt-get install -y \
-		tideways-php=$TIDEWAYS_PHP_VERSION \
+	apt-get install -y --no-install-recommends \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		arm64) arch='arm64' checksum="$TIDEWAYS_PHP_SHA256_ARM64" ;; \
+		amd64) arch='x86_64' checksum="$TIDEWAYS_PHP_SHA256_X64" ;; \
+		*) echo >&2 "error: unsupported architecture: $dpkgArch"; exit 1 ;; \
+	esac; \
+	\
+	curl -fsSL "https://tideways.s3.amazonaws.com/extension/${TIDEWAYS_PHP_VERSION}/tideways-php-${TIDEWAYS_PHP_VERSION}-${arch}.tar.gz" -o tideways-php.tar.gz; \
+	echo "$checksum *tideways-php.tar.gz" |sha256sum -c; \
+	mkdir -p /tmp/tideways/; \
+	tar xvf tideways-php.tar.gz --strip-components=1 -C /tmp/tideways/; \
+	cp /tmp/tideways/*.so /tideways/; \
+	\
+	rm -r /tmp/tideways/; \
+	rm tideways-php.tar.gz; \
+	apt-get purge -y --auto-remove \
+		$buildDeps; \
+	rm -rf /var/lib/apt/lists/*;

--- a/php/alpine/Dockerfile
+++ b/php/alpine/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3.19
 
 LABEL org.opencontainers.image.source="https://github.com/tideways/container-images"
 
+COPY --chmod=0755 get-ext-path.php /tideways/
+
 ENV TIDEWAYS_PHP_VERSION 5.9.0
 ENV TIDEWAYS_PHP_SHA256_X64 7fcec20e09c1b6753d949c5159a03b21249220d333725d82a0758061479fe22c
 ENV TIDEWAYS_PHP_SHA256_ARM64 2bbf1214215c9b3d1e589ef87371ad3a17465702f014a311be56ad23f384eab7
@@ -10,15 +12,20 @@ RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		curl \
 	; \
+	\
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
 		aarch64) arch='arm64' checksum="$TIDEWAYS_PHP_SHA256_ARM64" ;; \
 		x86_64) arch='x86_64' checksum="$TIDEWAYS_PHP_SHA256_X64" ;; \
 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
 	esac; \
+	\
 	curl -fsSL "https://tideways.s3.amazonaws.com/extension/${TIDEWAYS_PHP_VERSION}/tideways-php-${TIDEWAYS_PHP_VERSION}-alpine-${arch}.tar.gz" -o tideways-php-alpine.tar.gz; \
 	echo "$checksum *tideways-php-alpine.tar.gz" |sha256sum -c; \
-	mkdir -p /usr/lib/tideways/; \
-	tar xvf tideways-php-alpine.tar.gz --strip-components=1 -C /usr/lib/tideways/; \
+	mkdir -p /tmp/tideways/; \
+	tar xvf tideways-php-alpine.tar.gz --strip-components=1 -C /tmp/tideways/; \
+	cp /tmp/tideways/*.so /tideways/; \
+	\
+	rm -r /tmp/tideways/; \
 	rm tideways-php-alpine.tar.gz; \
 	apk del --no-network .build-deps;

--- a/php/alpine/get-ext-path.php
+++ b/php/alpine/get-ext-path.php
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+
+$fullPath = sprintf(
+	"%s/tideways-php%s-%d.%d%s.so",
+	__DIR__,
+	file_exists("/lib/apk/db/installed") ? "-alpine" : "",
+	PHP_MAJOR_VERSION,
+	PHP_MINOR_VERSION,
+	PHP_ZTS ? "-zts" : ""
+);
+
+if (!\is_file($fullPath)) {
+	fwrite(STDERR, "Unable to determine extension path: $fullPath");
+	exit(1);
+}
+
+echo $fullPath;

--- a/php/get-ext-path.php
+++ b/php/get-ext-path.php
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+
+$fullPath = sprintf(
+	"%s/tideways-php%s-%d.%d%s.so",
+	__DIR__,
+	file_exists("/lib/apk/db/installed") ? "-alpine" : "",
+	PHP_MAJOR_VERSION,
+	PHP_MINOR_VERSION,
+	PHP_ZTS ? "-zts" : ""
+);
+
+if (!\is_file($fullPath)) {
+	fwrite(STDERR, "Unable to determine extension path: $fullPath");
+	exit(1);
+}
+
+echo $fullPath;

--- a/update.sh
+++ b/update.sh
@@ -17,8 +17,12 @@ mv -f daemon/Dockerfile.new daemon/Dockerfile
 TIDEWAYS_PHP_VERSION="$(echo "$versions" |jq -r '.php.version')"
 awk \
 	-v "TIDEWAYS_PHP_VERSION=$TIDEWAYS_PHP_VERSION" \
+	-v "TIDEWAYS_PHP_SHA256_X64=$(curl -fsSL "https://tideways.s3.amazonaws.com/extension/${TIDEWAYS_PHP_VERSION}/tideways-php-${TIDEWAYS_PHP_VERSION}-x86_64.tar.gz" |sha256sum |cut -d' ' -f1)" \
+	-v "TIDEWAYS_PHP_SHA256_ARM64=$(curl -fsSL "https://tideways.s3.amazonaws.com/extension/${TIDEWAYS_PHP_VERSION}/tideways-php-${TIDEWAYS_PHP_VERSION}-arm64.tar.gz" |sha256sum |cut -d' ' -f1)" \
 	' \
 		$1 == "ENV" && $2 == "TIDEWAYS_PHP_VERSION"{$3 = TIDEWAYS_PHP_VERSION}
+		$1 == "ENV" && $2 == "TIDEWAYS_PHP_SHA256_X64"{$3 = TIDEWAYS_PHP_SHA256_X64} \
+		$1 == "ENV" && $2 == "TIDEWAYS_PHP_SHA256_ARM64"{$3 = TIDEWAYS_PHP_SHA256_ARM64} \
 		{print} \
 	' \
 	< php/Dockerfile > php/Dockerfile.new


### PR DESCRIPTION
Besides making the instructions simpler, this also improves the robustness of the Docker image, because we can adjust filenames and directory structure as necessary.

The Debian Dockerfile has been synchronized with the Alpine one, embedded the SHA-256 hash of the regular downloads, instead of going through `apt`, as this simplifies the placement in the top-level `/tideways/` directory without unecessary duplication or complicated cleanup.

The updated instructions are now as follows:

Debian:

    COPY --from=ghcr.io/tideways/php:latest /tideways/ /tideways/
    RUN docker-php-ext-enable --ini-name tideways.ini $(php /tideways/get-ext-path.php)

Alpine:

    COPY --from=ghcr.io/tideways/php:alpine /tideways/ /tideways/
    RUN docker-php-ext-enable --ini-name tideways.ini $(php /tideways/get-ext-path.php)

The previous instructions are no longer valid, but they have not yet been documented.