### PR TITLE
Enable caching in GitHub Actions

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -47,6 +47,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.organization }}/${{ env.image }}:latest,ghcr.io/${{ env.organization }}/${{ env.image }}:${{ steps.extract_version.outputs.version }}
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,6 +47,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.organization }}/${{ env.image }}:latest,ghcr.io/${{ env.organization }}/${{ env.image }}:${{ steps.extract_version.outputs.version }}
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ github.event_name != 'pull_request' }}
@@ -84,6 +86,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.organization }}/${{ env.image }}:alpine,ghcr.io/${{ env.organization }}/${{ env.image }}:${{ steps.extract_version.outputs.version }}-alpine
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This hopefully prevents spurious rebuilds even nothing changed in practice, leading to unnecessary repulls on the user’s end.