### PR TITLE
Rebuild the images daily

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: '0 12 * * 3'
+    - cron: '0 12 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: '0 12 * * 3'
+    - cron: '0 12 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Caches in GitHub Actions live for at most 1 week, a weekly rebuild thus might not reliably see cache hits.

Rebuild the image daily, with caching enabled, it should actually result in a new image and it will pick up rebuilds of the base image (in case of the daemon image) more quickly.