### PR TITLE
Specify `scope` for GitHub Action Caching

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -47,8 +47,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.organization }}/${{ env.image }}:latest,ghcr.io/${{ env.organization }}/${{ env.image }}:${{ steps.extract_version.outputs.version }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ env.image }}
+          cache-to: type=gha,scope=${{ env.image }},mode=max
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,8 +47,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.organization }}/${{ env.image }}:latest,ghcr.io/${{ env.organization }}/${{ env.image }}:${{ steps.extract_version.outputs.version }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ env.image }}
+          cache-to: type=gha,scope=${{ env.image }},mode=max
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ github.event_name != 'pull_request' }}
@@ -86,8 +86,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/${{ env.organization }}/${{ env.image }}:alpine,ghcr.io/${{ env.organization }}/${{ env.image }}:${{ steps.extract_version.outputs.version }}-alpine
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ env.image }}-alpine
+          cache-to: type=gha,scope=${{ env.image }}-alpine,mode=max
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Without the `scope` the caches for all images will be intermingled, preventing cache hits for the PHP images.

see https://docs.docker.com/build/cache/backends/gha/#scope